### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gray2015
 [![Build Status](https://travis-ci.org/globalbioticinteractions/gray2015.svg)](https://travis-ci.org/globalbioticinteractions/gray2015) [![DOI](https://zenodo.org/badge/48884420.svg)](https://zenodo.org/badge/latestdoi/48884420) [![GloBI](http://api.globalbioticinteractions.org/interaction.svg?accordingTo=globalbioticinteractions/gray2015)](http://globalbioticinteractions.org/?accordingTo=globalbioticinteractions/gray2015)
 
-Discover data in Gray C, Ma A, Perkins D, Hudson L, Figueroa D, Woodward G (2015). Database of trophic interactions. Zenodo. http://dx.doi.org/10.5281/zenodo.13751
+Discover data in Gray C, Ma A, Perkins D, Hudson L, Figueroa D, Woodward G (2015). Database of trophic interactions. Zenodo. https://doi.org/10.5281/zenodo.13751
 
 Available through http://globalbioticinteractions.org .

--- a/globi.json
+++ b/globi.json
@@ -1,5 +1,5 @@
-{ "citation": "Gray C, Ma A, Perkins D, Hudson L, Figueroa D, Woodward G (2015). Database of trophic interactions. Zenodo. http://dx.doi.org/10.5281/zenodo.13751",
-  "doi": "http://dx.doi.org/10.5281/zenodo.13751",
+{ "citation": "Gray C, Ma A, Perkins D, Hudson L, Figueroa D, Woodward G (2015). Database of trophic interactions. Zenodo. https://doi.org/10.5281/zenodo.13751",
+  "doi": "https://doi.org/10.5281/zenodo.13751",
   "format": "gray",
   "resources": {
     "links": "https://zenodo.org/record/13751/files/trophic.links.2014-11-10.csv"  


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates all DOI links.

Cheers!